### PR TITLE
chore: rebalance Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "wednesday"
       time: "08:00"
       timezone: "Europe/Madrid"
     open-pull-requests-limit: 5
@@ -22,7 +22,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "wednesday"
       time: "08:30"
       timezone: "Europe/Madrid"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Rebalance the weekly Dependabot load across repositories after several repositories were frozen or archived.

Changes in this repository:
- Move pip and GitHub Actions updates from Monday to Wednesday.
- Preserve the existing time spacing, groups, ignore rules, and pull-request limits.

This contributes to a portfolio-wide target of 4-5 Dependabot update blocks per day.